### PR TITLE
feat: add set_timer interface for s-mode eapp, and disable timer redirection now

### DIFF
--- a/opensbi-0.9/include/sm/sm.h
+++ b/opensbi-0.9/include/sm/sm.h
@@ -35,6 +35,7 @@ extern uintptr_t _fw_start[], _fw_end[];
 #define SBI_EXIT_ENCLAVE        99
 #define SBI_ENCLAVE_OCALL        98
 #define SBI_GET_KEY             88
+#define SBI_SET_TIMER             89
 
 //Error code of SBI_ALLOC_ENCLAVE_MEM
 #define ENCLAVE_NO_MEMORY       -2

--- a/opensbi-0.9/lib/sbi/sbi_ecall_penglai.c
+++ b/opensbi-0.9/lib/sbi/sbi_ecall_penglai.c
@@ -8,6 +8,7 @@
 #include <sbi/sbi_ecall_interface.h>
 #include <sbi/sbi_error.h>
 #include <sbi/sbi_trap.h>
+#include <sbi/sbi_timer.h>
 #include <sbi/sbi_version.h>
 #include <sbi/riscv_asm.h>
 #include <sbi/sbi_console.h>
@@ -87,6 +88,14 @@ static int sbi_ecall_penglai_enclave_handler(unsigned long extid, unsigned long 
 			break;
 		case SBI_GET_KEY:
 			ret = sm_enclave_get_key((uintptr_t *)regs, regs->a0, regs->a1, regs->a2, regs->a3);
+			break;
+		case SBI_SET_TIMER:
+		#if __riscv_xlen == 32
+				sbi_timer_event_start((((u64)regs->a1 << 32) | (u64)regs->a0));
+		#else
+				sbi_timer_event_start((u64)regs->a0);
+		#endif
+			ret = 0;
 			break;
 		default:
 			sbi_printf("[Penglai@Monitor] enclave interface(funcid:%ld) not supported yet\n", funcid);

--- a/opensbi-0.9/lib/sbi/sbi_trap.c
+++ b/opensbi-0.9/lib/sbi/sbi_trap.c
@@ -229,11 +229,15 @@ void sbi_trap_handler(struct sbi_trap_regs *regs)
 		mcause &= ~(1UL << (__riscv_xlen - 1));
 		switch (mcause) {
 		case IRQ_M_TIMER:
+#if 0
 			if (check_in_enclave_world() >= 0) { //handle timer for enclaves
 				sm_do_timer_irq((uintptr_t *)regs, mcause, regs->mepc);
 			}else{
 				sbi_timer_process();
 			}
+#else
+				sbi_timer_process();
+#endif
 			break;
 		case IRQ_M_SOFT:
 			sbi_ipi_process();


### PR DESCRIPTION
 The only way to leave the enclave is invoking `eapp_return`.

Signed-off-by: Dong Du <dd_nirvana@sjtu.edu.cn>